### PR TITLE
fix Offset size counting

### DIFF
--- a/src/SplitLayout.js
+++ b/src/SplitLayout.js
@@ -117,7 +117,8 @@ export default class SplitLayout extends React.Component {
       return;
     }
 
-    const minEdgePosition = this.props.direction === 'vertical' ? this.state.node.offsetLeft : this.state.node.offsetTop;
+    var boundingClientOffset = this.state.node.getBoundingClientRect();
+    var minEdgePosition = this.props.direction === 'vertical' ? boundingClientOffset.left : boundingClientOffset.top;
     const currentPosition = this.props.direction === 'vertical' ? event.clientX : event.clientY;
     const size = currentPosition - minEdgePosition;
     const index = this.state.index;


### PR DESCRIPTION
I found an issue and try to fix it.
The problem appears when I nested Split Layout into another element. It doesn't count size from left side and from top correctly.
(https://github.com/siuying/react-split-layout/issues/2)
